### PR TITLE
Removed nginx version display

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -14,6 +14,7 @@ http {
   tcp_nopush on;
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
 
   server {
     listen <%= ENV["PORT"] %>;


### PR DESCRIPTION
Added server_tokens off configuration to remove nginx version on error pages to conform with security best practices and improve asthetics.