### PR TITLE
correctly redirect http to https

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -39,7 +39,7 @@ http {
       auth_basic_user_file <%= auth_file %>;  #For Basic Auth
       <% end %>
       <% if ENV["FORCE_HTTPS"] %>
-      if ($http_x_forwarded_proto = http) {
+      if ($http_x_forwarded_proto != "https") {
         return 301 https://$host$request_uri;
       }
       <% end %>


### PR DESCRIPTION
Solves #55 since the `$http_x_forwarded_proto` variable doesn't always default to "http" for http traffic but rather to "-".