### PR TITLE
correctly redirect http to https

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -39,7 +39,7 @@ http {
       auth_basic_user_file <%= auth_file %>;  #For Basic Auth
       <% end %>
       <% if ENV["FORCE_HTTPS"] %>
-      if ($http_x_forwarded_proto = http) {
+      if ($http_x_forwarded_proto != "https") {
         return 301 https://$host$request_uri;
       }
       <% end %>


### PR DESCRIPTION
Resolves #55 since http requests don't always default to `x_forwarded_proto = "http"` but rather mostly to `x_forwarded_proto = "-"`.