### PR TITLE
Specify charset of HTML chars in nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,6 +5,7 @@ error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
 events { worker_connections 1024; }
 
 http {
+  charset utf-8;
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
   access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;


### PR DESCRIPTION
If this isn't set, the server doesn't handle special characters correctly. For example, ♯ was rendering as á. 

I don't know much (anything) about nginx, so I'm not sure if this fix has any trade-offs or negative repercussions. But this is the second time I've had this issue with serving a static site via nginx, so I thought I should at least make a PR.

Alternatively, is there any way to configure the `nginx.conf` from my own project? It looks like there's some configuration that can be put in `Staticfile`, is there a way to make arbitrary changes to the `nginx.conf` from there?

Cheers.