### PR TITLE
Option to enable html5 push state

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ For information on deploying static sites visit [CloudFoundry.org](http://docs.c
 1. Build the buildpack
 
   ```shell
-  BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager [ --uncached | --cached ]
+  BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager [ --cached | --uncached ]
+  ```
 
 1. Use in Cloud Foundry
 

--- a/bin/compile
+++ b/bin/compile
@@ -80,4 +80,10 @@ if [[ -e "Staticfile" && "$(grep 'ssi: enabled' Staticfile)X" != "X" ]]; then
   touch nginx/conf/.enable_ssi
 fi
 
+# Enable pushstate module
+if [[ -e "Staticfile" && "$(grep 'pushstate: enabled' Staticfile)X" != "X" ]]; then
+  status "Enabling pushstate"
+  touch nginx/conf/.enable_pushstate
+fi
+
 cp $compile_buildpack_bin/boot.sh .

--- a/cf_spec/fixtures/pushstate/Staticfile
+++ b/cf_spec/fixtures/pushstate/Staticfile
@@ -1,0 +1,1 @@
+pushstate: enabled

--- a/cf_spec/fixtures/pushstate/index.html
+++ b/cf_spec/fixtures/pushstate/index.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <p>
+      This is the index file
+    </p>
+  </body>
+</html>

--- a/cf_spec/fixtures/pushstate/static.html
+++ b/cf_spec/fixtures/pushstate/static.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <p>
+      This is a static file
+    </p>
+  </body>
+</html>

--- a/cf_spec/integration/deploy_pushstate_app_spec.rb
+++ b/cf_spec/integration/deploy_pushstate_app_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'deploy a staticfile app' do
+  let(:app) { Machete.deploy_app('pushstate') }
+  let(:browser) { Machete::Browser.new(app) }
+
+  after do
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+
+  specify do
+    expect(app).to be_running
+  end
+
+  context 'requesting the index file' do
+    it 'returns the index file' do
+      browser.visit_path('/')
+      expect(browser).to have_body('This is the index file')
+    end
+  end
+
+  context 'requesting a static file' do
+    it 'returns the static file' do
+      browser.visit_path('/static.html')
+      expect(browser).to have_body('This is a static file')
+    end
+  end
+
+  context 'requesting a inexistent file' do
+    it 'returns the index file' do
+      browser.visit_path('/inexistent')
+      expect(browser).to have_body('This is the index file')
+    end
+  end
+end

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,6 +33,11 @@ http {
 
     location / {
       root <%= ENV["APP_ROOT"] %>/public;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
+      if (!-e $request_filename) {
+        rewrite ^(.*)$ / break;
+      }
+      <% end %>
       index index.html index.htm Default.htm;
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
         autoindex on;


### PR DESCRIPTION
The `nginx.conf` now has an additional rewrite rule that is active when `pushstate: enabled` is present in the `Staticfile`. It rewrites all requests that don't match a file on disk to the root, which in turn points to the index file. Works for me, but as I'm no nginx expert, please give it a thorough review. 

This enables us to deploy static apps that rely on HTML5 push state, where all requests should be routed to the index file (eg. an angular application).

Even though I think this is a very frequent use case, I did not find a specific buildpack for it. Happy if you point me to an existing one and don't want to support this in `staticfile-buildpack`.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch