### PR TITLE
Feature/ssi expose vcap services

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,6 +80,12 @@ if [[ -e "Staticfile" && "$(grep 'ssi: enabled' Staticfile)X" != "X" ]]; then
   touch nginx/conf/.enable_ssi
 fi
 
+# Enable ssi VCAP_SERVICES expose module
+if [[ -e "Staticfile" && "$(grep 'ssi_expose: enabled' Staticfile)X" != "X" ]]; then
+  status "Enabling ssi VCAP_SERVICES expose"
+  touch nginx/conf/.enable_ssi_expose
+fi
+
 # Enable pushstate module
 if [[ -e "Staticfile" && "$(grep 'pushstate: enabled' Staticfile)X" != "X" ]]; then
   status "Enabling pushstate"

--- a/cf_spec/fixtures/ssi_expose_disabled_app/index.html
+++ b/cf_spec/fixtures/ssi_expose_disabled_app/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <!--#echo var="vcap_services" -->
+  </body>
+</html>

--- a/cf_spec/fixtures/ssi_expose_enabled_app/Staticfile
+++ b/cf_spec/fixtures/ssi_expose_enabled_app/Staticfile
@@ -1,0 +1,1 @@
+ssi_expose: enabled

--- a/cf_spec/fixtures/ssi_expose_enabled_app/index.html
+++ b/cf_spec/fixtures/ssi_expose_enabled_app/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <!--#echo var="vcap_services" -->
+  </body>
+</html>

--- a/cf_spec/integration/deploy_ssi_expose_app_spec.rb
+++ b/cf_spec/integration/deploy_ssi_expose_app_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'deploy a staticfile app' do
+  let(:browser) { Machete::Browser.new(app) }
+  let(:timestamp) { Time.now.to_s }
+
+  after do
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+
+  context 'ssi expose is toggled on' do
+    let(:app) { Machete.deploy_app('ssi_expose_enabled_app') }
+
+    specify do
+      expect(app).to be_running
+
+      browser.visit_path('/')
+      expect(browser).to_not have_body('<!--#echo var="vcap_services" -->')
+    end
+  end
+
+  context 'ssi expose is toggled off' do
+    let(:app) { Machete.deploy_app('ssi_expose_disabled_app') }
+
+    specify do
+      expect(app).to be_running
+
+      browser.visit_path('/')
+      expect(browser).to have_body('<!--#echo var="vcap_services" -->')
+    end
+  end
+end

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -51,8 +51,11 @@ http {
           return 301 https://$host$request_uri;
         }
       <% end %>
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) || File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi_expose")) %>
         ssi on;
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi_expose")) %>
+        set $vcap_services '<%= ENV["VCAP_SERVICES"] %>';
       <% end %>
     }
   }


### PR DESCRIPTION
##A short explanation of the change:
Add an new option to the Staticfile to expose VCAP_SERVICES over SSI to a web client.

##An explanation of the use cases your change solves
If I have an oAuth as a service (e.g. UAA) exposed with the service broker and like to expose oAuth client infos over app bindings to the web client, that the web client can dynamically use this info to make a proper authentication.

##Test
Added two tests and both pass.

##Additional steps
- PR for documentation of the feature for https://github.com/cloudfoundry/docs-buildpacks
