### PR TITLE
Ensure hidden files and directories in root get copied across to public

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,6 +41,7 @@ fi
 
 status "Copying project files into public/"
 shopt -s extglob
+shopt -s dotglob 
 root_dir_absolute=`cd $root_dir 2>/dev/null && pwd -P`
 if [ ${build_dir}/public != ${root_dir_absolute} ]; then
   tmp_dir=`mktemp -d /tmp/XXXXX`
@@ -49,6 +50,7 @@ if [ ${build_dir}/public != ${root_dir_absolute} ]; then
   mv $tmp_dir  $build_dir/public
 fi
 shopt -u extglob
+shopt -u dotglob 
 
 
 


### PR DESCRIPTION
Hi,

I've noticed that the buildpack will not allow hidden files (those beginning with a `.`) in the root directory. This causes problems trying to serve static paths that start with a `.` for instance http://example.com/.foo/bar/baz.html.

Subdirectories are not problem so http://example.com/foo/.bar/baz.html is perfectly possible.

It does not appear that this is deliberate, but enabling this change may expose files that people are not expecting to become available (`.idea` etc). I think in these cases it would be possible to use `cfignore`.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

Cheers,

Theo