### PR TITLE
Add MIME types for TTF, WOFF, WOFF2 fonts

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -7,6 +7,9 @@ types {
   application/x-javascript js;
   application/atom+xml atom;
   application/rss+xml rss;
+  font/ttf ttf;
+  font/woff woff;
+  font/woff2 woff2;
   text/mathml mml;
   text/plain txt;
   text/vnd.sun.j2me.app-descriptor jad;


### PR DESCRIPTION
As specified in https://www.iana.org/assignments/media-types/media-types.xhtml#font

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
add MIME types for TTF, WOFF, WOFF2 fonts 

* An explanation of the use cases your change solves
to enable setting `Expires` for fonts without modifying default `mime.types`  as discussed in https://github.com/cloudfoundry/staticfile-buildpack/issues/87

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
