### PR TITLE
Support for ContextPath

### DIFF
--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -79,7 +79,11 @@ http {
 
     {{range .ContextPaths}}
       location {{.}} {
-        root <%= ENV["APP_ROOT"] %>/public;
+        {{if eq . "/" }}
+          root <%= ENV["APP_ROOT"] %>/public;
+        {{else}}
+          alias <%= ENV["APP_ROOT"] %>/public;
+        {{end}}
 
         {{if $.PushState}}
           if (!-e $request_filename) {

--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -77,50 +77,52 @@ http {
     listen <%= ENV["PORT"] %>;
     server_name localhost;
 
-    location / {
-      root <%= ENV["APP_ROOT"] %>/public;
+    {{range .ContextPaths}}
+      location {{.}} {
+        root <%= ENV["APP_ROOT"] %>/public;
 
-      {{if .PushState}}
-        if (!-e $request_filename) {
-          rewrite ^(.*)$ / break;
-        }
-      {{end}}
+        {{if $.PushState}}
+          if (!-e $request_filename) {
+            rewrite ^(.*)$ / break;
+          }
+        {{end}}
 
-      index index.html index.htm Default.htm;
+        index index.html index.htm Default.htm;
 
-      {{if .DirectoryIndex}}
-        autoindex on;
-      {{end}}
+        {{if $.DirectoryIndex}}
+          autoindex on;
+        {{end}}
 
-      {{if .BasicAuth}}
-        auth_basic "Restricted";  #For Basic Auth
-        auth_basic_user_file <%= ENV["APP_ROOT"] %>/nginx/conf/.htpasswd;
-      {{end}}
+        {{if $.BasicAuth}}
+          auth_basic "Restricted";  #For Basic Auth
+          auth_basic_user_file <%= ENV["APP_ROOT"] %>/nginx/conf/.htpasswd;
+        {{end}}
 
-      {{if .ForceHTTPS}}
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
-      {{else}}
-      <% if ENV["FORCE_HTTPS"] %>
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
-      <% end %>
-      {{end}}
+        {{if $.ForceHTTPS}}
+          if ($http_x_forwarded_proto != "https") {
+            return 301 https://$host$request_uri;
+          }
+        {{else}}
+        <% if ENV["FORCE_HTTPS"] %>
+          if ($http_x_forwarded_proto != "https") {
+            return 301 https://$host$request_uri;
+          }
+        <% end %>
+        {{end}}
 
-      {{if .SSI}}
-        ssi on;
-      {{end}}
+        {{if $.SSI}}
+          ssi on;
+        {{end}}
 
-      {{if .HSTS}}
-        add_header Strict-Transport-Security "max-age=31536000";
-      {{end}}
+        {{if $.HSTS}}
+          add_header Strict-Transport-Security "max-age=31536000";
+        {{end}}
 
-      {{if ne .LocationInclude ""}}
-        include {{.LocationInclude}};
-      {{end}}
-    }
+        {{if ne $.LocationInclude ""}}
+          include {{$.LocationInclude}};
+        {{end}}
+      }
+    {{end}}
 
   {{if not .HostDotFiles}}
     location ~ /\. {

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -317,6 +317,7 @@ func (sf *Finalizer) generateNginxConf() (string, error) {
 	buffer := new(bytes.Buffer)
 
 	t := template.Must(template.New("nginx.conf").Parse(nginxConfTemplate))
+
 	err := t.Execute(buffer, sf.Config)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- Buildpack would automatically detect the contextPath and add the location block accordingly.
- Could use some more cleanup and I believe the logic to get the ContextPath could be part of the https://github.com/cloudfoundry/libbuildpack repo.

* A short explanation of the proposed change:
When the users have ` context-path ` in route the directive ` location / ` won't work as expected.
So we should honor the contextPath information and come up ` location ` directive accordingly.

* An explanation of the use cases your change solves

if the ` manifest.yml` have [route](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#routes) information like 
```
routes:
    - route: hostname.domain.com/contextpath
```

the  nginx.conf should know about this so that it can serve the files properly.


* [x] I have made this pull request to the `develop` branch

* [x] I have viewed signed and have submitted the Contributor License Agreement
Should have 
* [ ] I have added an integration test
Nope, Not so familiar with Ruby 😢 , Would have loved to do it, but the fact that I've to have the whole bosh-lite and cf-release run on my local pulled me off.  (Will try to write this , if this proposal seems good)

Have written couple of unit tests and deployed an application using the code from my repo.
```
buildpack: https://github.com/sks/staticfile-buildpack#feature/support_for_context_path
```


NB: The changes are  more readable if read with [ignoring whitespace changes](https://github.com/cloudfoundry/staticfile-buildpack/pull/105/files?w=1)