### PR TITLE
Add opt-in richer HSTS support

### DIFF
--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -114,7 +114,7 @@ http {
       {{end}}
 
       {{if .HSTS}}
-        add_header Strict-Transport-Security "max-age=31536000 {{if .HSTSIncludeSubDomains}}includeSubDomains;{{end}} {{if .HSTSPreload}}preload{{end}}";
+        add_header Strict-Transport-Security "max-age=31536000{{if .HSTSIncludeSubDomains}}; includeSubDomains{{end}}{{if .HSTSPreload}}; preload{{end}}";
       {{end}}
 
       {{if ne .LocationInclude ""}}

--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -114,7 +114,7 @@ http {
       {{end}}
 
       {{if .HSTS}}
-        add_header Strict-Transport-Security "max-age=31536000";
+        add_header Strict-Transport-Security "max-age=31536000 {{if .HSTSIncludeSubDomains}}includeSubDomains;{{end}} {{if .HSTSPreload}}preload{{end}}";
       {{end}}
 
       {{if ne .LocationInclude ""}}

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -161,6 +161,7 @@ func (sf *Finalizer) LoadStaticfile() error {
 			if isEnabled {
 				sf.Log.BeginStep("Enabling HSTS and HSTS Preload")
 				conf.HSTS = true
+				conf.HSTSIncludeSubDomains = true
 				conf.HSTSPreload = true
 			}
 		case "force_https":

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -14,15 +14,17 @@ import (
 )
 
 type Staticfile struct {
-	RootDir         string `yaml:"root"`
-	HostDotFiles    bool   `yaml:"host_dot_files"`
-	LocationInclude string `yaml:"location_include"`
-	DirectoryIndex  bool   `yaml:"directory"`
-	SSI             bool   `yaml:"ssi"`
-	PushState       bool   `yaml:"pushstate"`
-	HSTS            bool   `yaml:"http_strict_transport_security"`
-	ForceHTTPS      bool   `yaml:"force_https"`
-	BasicAuth       bool
+	RootDir               string `yaml:"root"`
+	HostDotFiles          bool   `yaml:"host_dot_files"`
+	LocationInclude       string `yaml:"location_include"`
+	DirectoryIndex        bool   `yaml:"directory"`
+	SSI                   bool   `yaml:"ssi"`
+	PushState             bool   `yaml:"pushstate"`
+	HSTS                  bool   `yaml:"http_strict_transport_security"`
+	HSTSIncludeSubDomains bool   `yaml:"http_strict_transport_security_include_subdomains"`
+	HSTSPreload           bool   `yaml:"http_strict_transport_security_preload"`
+	ForceHTTPS            bool   `yaml:"force_https"`
+	BasicAuth             bool
 }
 
 type YAML interface {
@@ -148,6 +150,18 @@ func (sf *Finalizer) LoadStaticfile() error {
 			if isEnabled {
 				sf.Log.BeginStep("Enabling HSTS")
 				conf.HSTS = true
+			}
+		case "http_strict_transport_security_include_subdomains":
+			if isEnabled {
+				sf.Log.BeginStep("Enabling HSTS and HSTS includeSubDomains")
+				conf.HSTS = true
+				conf.HSTSIncludeSubDomains = true
+			}
+		case "http_strict_transport_security_preload":
+			if isEnabled {
+				sf.Log.BeginStep("Enabling HSTS and HSTS Preload")
+				conf.HSTS = true
+				conf.HSTSPreload = true
 			}
 		case "force_https":
 			if isEnabled {

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -153,15 +153,12 @@ func (sf *Finalizer) LoadStaticfile() error {
 			}
 		case "http_strict_transport_security_include_subdomains":
 			if isEnabled {
-				sf.Log.BeginStep("Enabling HSTS and HSTS includeSubDomains")
-				conf.HSTS = true
+				sf.Log.BeginStep("Enabling HSTS includeSubDomains")
 				conf.HSTSIncludeSubDomains = true
 			}
 		case "http_strict_transport_security_preload":
 			if isEnabled {
-				sf.Log.BeginStep("Enabling HSTS, HSTS includeSubDomains, and HSTS Preload")
-				conf.HSTS = true
-				conf.HSTSIncludeSubDomains = true
+				sf.Log.BeginStep("Enabling HSTS Preload")
 				conf.HSTSPreload = true
 			}
 		case "force_https":
@@ -170,6 +167,11 @@ func (sf *Finalizer) LoadStaticfile() error {
 				conf.ForceHTTPS = true
 			}
 		}
+	}
+
+	if !conf.HSTS && (conf.HSTSIncludeSubDomains || conf.HSTSPreload) {
+		sf.Log.Warning("http_strict_transport_security is not enabled while http_strict_transport_security_include_subdomains or http_strict_transport_security_preload have been enabled.")
+		sf.Log.Protip("http_strict_transport_security_include_subdomains and http_strict_transport_security_preload do nothing without http_strict_transport_security enabled. http://docs.cloudfoundry.org/buildpacks/staticfile/index.html#strict-security")
 	}
 
 	authFile := filepath.Join(sf.BuildDir, "Staticfile.auth")

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -159,7 +159,7 @@ func (sf *Finalizer) LoadStaticfile() error {
 			}
 		case "http_strict_transport_security_preload":
 			if isEnabled {
-				sf.Log.BeginStep("Enabling HSTS and HSTS Preload")
+				sf.Log.BeginStep("Enabling HSTS, HSTS includeSubDomains, and HSTS Preload")
 				conf.HSTS = true
 				conf.HSTSIncludeSubDomains = true
 				conf.HSTSPreload = true

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -254,11 +254,10 @@ var _ = Describe("Compile", func() {
 					})
 				})
 				It("sets http_strict_transport_security_include_subdomain", func() {
-					Expect(finalizer.Config.HSTS).To(Equal(true))
 					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
 				})
 				It("Logs", func() {
-					Expect(buffer.String()).To(Equal("-----> Enabling HSTS and HSTS includeSubDomains\n"))
+					Expect(buffer.String()).To(Equal("-----> Enabling HSTS includeSubDomains\n"))
 				})
 			})
 
@@ -269,12 +268,10 @@ var _ = Describe("Compile", func() {
 					})
 				})
 				It("sets http_strict_transport_security_preload", func() {
-					Expect(finalizer.Config.HSTS).To(Equal(true))
-					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
 					Expect(finalizer.Config.HSTSPreload).To(Equal(true))
 				})
 				It("Logs", func() {
-					Expect(buffer.String()).To(Equal("-----> Enabling HSTS and HSTS Preload\n"))
+					Expect(buffer.String()).To(Equal("-----> Enabling HSTS Preload\n"))
 				})
 			})
 

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -255,6 +255,7 @@ var _ = Describe("Compile", func() {
 				})
 				It("sets http_strict_transport_security_include_subdomain", func() {
 					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
+					Expect(finalizer.Config.HSTS).To(Equal(false))
 				})
 				It("Logs", func() {
 					Expect(buffer.String()).To(Equal("-----> Enabling HSTS includeSubDomains\n"))
@@ -269,6 +270,7 @@ var _ = Describe("Compile", func() {
 				})
 				It("sets http_strict_transport_security_preload", func() {
 					Expect(finalizer.Config.HSTSPreload).To(Equal(true))
+					Expect(finalizer.Config.HSTS).To(Equal(false))
 				})
 				It("Logs", func() {
 					Expect(buffer.String()).To(Equal("-----> Enabling HSTS Preload\n"))
@@ -652,6 +654,31 @@ var _ = Describe("Compile", func() {
 				})
 			})
 
+			Context("http_strict_transport_security and http_strict_transport_security_include_subdomain is set in staticfile", func() {
+				BeforeEach(func() {
+					staticfile.HSTS = true
+					staticfile.HSTSIncludeSubDomains = true
+				})
+				It("it adds the HSTS header", func() {
+					data, err = ioutil.ReadFile(filepath.Join(buildDir, "nginx", "conf", "nginx.conf"))
+					Expect(err).To(BeNil())
+					Expect(string(data)).To(ContainSubstring(`add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";`))
+				})
+			})
+
+			Context("http_strict_transport_security, http_strict_transport_security_include_subdomain, and http_strict_transport_security_preload is set in staticfile", func() {
+				BeforeEach(func() {
+					staticfile.HSTS = true
+					staticfile.HSTSIncludeSubDomains = true
+					staticfile.HSTSPreload = true
+				})
+				It("it adds the HSTS header", func() {
+					data, err = ioutil.ReadFile(filepath.Join(buildDir, "nginx", "conf", "nginx.conf"))
+					Expect(err).To(BeNil())
+					Expect(string(data)).To(ContainSubstring(`add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";`))
+				})
+			})
+
 			Context("http_strict_transport_security is NOT set in staticfile", func() {
 				BeforeEach(func() {
 					staticfile.HSTS = false
@@ -662,6 +689,20 @@ var _ = Describe("Compile", func() {
 					Expect(string(data)).NotTo(ContainSubstring(`add_header Strict-Transport-Security "max-age=31536000";`))
 				})
 			})
+
+			Context("http_strict_transport_security is NOT set in staticfile, but http_strict_transport_security_preload or http_strict_transport_security_include_subdomain are set in staticfile", func() {
+				BeforeEach(func() {
+					staticfile.HSTS = false
+					staticfile.HSTSIncludeSubDomains = true
+					staticfile.HSTSPreload = true
+				})
+				It("it does not add the HSTS header", func() {
+					data, err = ioutil.ReadFile(filepath.Join(buildDir, "nginx", "conf", "nginx.conf"))
+					Expect(err).To(BeNil())
+					Expect(string(data)).NotTo(ContainSubstring(`add_header Strict-Transport-Security "max-age=31536000";`))
+				})
+			})
+
 
 			Context("force_https is set in staticfile", func() {
 				BeforeEach(func() {

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -135,6 +135,8 @@ var _ = Describe("Compile", func() {
 				Expect(finalizer.Config.SSI).To(Equal(false))
 				Expect(finalizer.Config.PushState).To(Equal(false))
 				Expect(finalizer.Config.HSTS).To(Equal(false))
+				Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(false))
+				Expect(finalizer.Config.HSTSPreload).To(Equal(false))
 				Expect(finalizer.Config.ForceHTTPS).To(Equal(false))
 				Expect(finalizer.Config.BasicAuth).To(Equal(false))
 			})
@@ -242,6 +244,36 @@ var _ = Describe("Compile", func() {
 				})
 				It("Logs", func() {
 					Expect(buffer.String()).To(Equal("-----> Enabling HSTS\n"))
+				})
+			})
+
+			Context("and sets http_strict_transport_security_include_subdomain", func() {
+				BeforeEach(func() {
+					mockYaml.EXPECT().Load(filepath.Join(buildDir, "Staticfile"), gomock.Any()).Do(func(_ string, hash *map[string]string) {
+						(*hash)["http_strict_transport_security_include_subdomain"] = "true"
+					})
+				})
+				It("sets pushstate", func() {
+					Expect(finalizer.Config.HSTS).To(Equal(true))
+					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
+				})
+				It("Logs", func() {
+					Expect(buffer.String()).To(Equal("-----> Enabling HSTS and HSTS includeSubDomains\n"))
+				})
+			})
+
+			Context("and sets http_strict_transport_security_preload", func() {
+				BeforeEach(func() {
+					mockYaml.EXPECT().Load(filepath.Join(buildDir, "Staticfile"), gomock.Any()).Do(func(_ string, hash *map[string]string) {
+						(*hash)["http_strict_transport_security_preload"] = "true"
+					})
+				})
+				It("sets pushstate", func() {
+					Expect(finalizer.Config.HSTS).To(Equal(true))
+					Expect(finalizer.Config.HSTSPreload).To(Equal(true))
+				})
+				It("Logs", func() {
+					Expect(buffer.String()).To(Equal("-----> Enabling HSTS and HSTS Preload\n"))
 				})
 			})
 

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -270,6 +270,7 @@ var _ = Describe("Compile", func() {
 				})
 				It("sets pushstate", func() {
 					Expect(finalizer.Config.HSTS).To(Equal(true))
+					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
 					Expect(finalizer.Config.HSTSPreload).To(Equal(true))
 				})
 				It("Logs", func() {

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Compile", func() {
 						(*hash)["http_strict_transport_security"] = "true"
 					})
 				})
-				It("sets pushstate", func() {
+				It("sets http_strict_transport_security", func() {
 					Expect(finalizer.Config.HSTS).To(Equal(true))
 				})
 				It("Logs", func() {
@@ -253,7 +253,7 @@ var _ = Describe("Compile", func() {
 						(*hash)["http_strict_transport_security_include_subdomain"] = "true"
 					})
 				})
-				It("sets pushstate", func() {
+				It("sets http_strict_transport_security_include_subdomain", func() {
 					Expect(finalizer.Config.HSTS).To(Equal(true))
 					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
 				})
@@ -268,7 +268,7 @@ var _ = Describe("Compile", func() {
 						(*hash)["http_strict_transport_security_preload"] = "true"
 					})
 				})
-				It("sets pushstate", func() {
+				It("sets http_strict_transport_security_preload", func() {
 					Expect(finalizer.Config.HSTS).To(Equal(true))
 					Expect(finalizer.Config.HSTSIncludeSubDomains).To(Equal(true))
 					Expect(finalizer.Config.HSTSPreload).To(Equal(true))


### PR DESCRIPTION
This patch adds [opt-in] richer HSTS support. We've had to add these properties
for our Nginx configuration a few times in the past. It would be nice to
have the buildpack include the whole header rather in our custom location.conf so
we can rely on a more feature-rich version of what shipped in [v1.3.13](https://github.com/cloudfoundry/staticfile-buildpack/releases/tag/v1.3.13).

cc: @konklone