### PR TITLE
Use HTTPS instead of HTTP links in readme and inline explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![CF Slack](https://www.google.com/s2/favicons?domain=www.slack.com) Join us on Slack](https://cloudfoundry.slack.com/messages/buildpacks/)
 
-A Cloud Foundry [buildpack](http://docs.cloudfoundry.org/buildpacks/) for static content such as websites (HTML/JS/CSS).
+A Cloud Foundry [buildpack](https://docs.cloudfoundry.org/buildpacks/) for static content such as websites (HTML/JS/CSS).
 
 ### Buildpack User Documentation
 
-Official buildpack documentation can be found at [staticfile buildpack docs](http://docs.cloudfoundry.org/buildpacks/staticfile/index.html).
+Official buildpack documentation can be found at [staticfile buildpack docs](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html).
 
 ### Building the Buildpack
 
@@ -73,7 +73,7 @@ Find our guidelines [here](./CONTRIBUTING.md).
 
 ### Help and Support
 
-Join the #buildpacks channel in our [Slack community](http://slack.cloudfoundry.org/) if you need any further assistance.
+Join the #buildpacks channel in our [Slack community](https://slack.cloudfoundry.org/) if you need any further assistance.
 
 ### Reporting Issues
 

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -171,7 +171,7 @@ func (sf *Finalizer) LoadStaticfile() error {
 
 	if !conf.HSTS && (conf.HSTSIncludeSubDomains || conf.HSTSPreload) {
 		sf.Log.Warning("http_strict_transport_security is not enabled while http_strict_transport_security_include_subdomains or http_strict_transport_security_preload have been enabled.")
-		sf.Log.Protip("http_strict_transport_security_include_subdomains and http_strict_transport_security_preload do nothing without http_strict_transport_security enabled.", "http://docs.cloudfoundry.org/buildpacks/staticfile/index.html#strict-security")
+		sf.Log.Protip("http_strict_transport_security_include_subdomains and http_strict_transport_security_preload do nothing without http_strict_transport_security enabled.", "https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#strict-security")
 	}
 
 	authFile := filepath.Join(sf.BuildDir, "Staticfile.auth")
@@ -179,7 +179,7 @@ func (sf *Finalizer) LoadStaticfile() error {
 	if err == nil {
 		conf.BasicAuth = true
 		sf.Log.BeginStep("Enabling basic authentication using Staticfile.auth")
-		sf.Log.Protip("Learn about basic authentication", "http://docs.cloudfoundry.org/buildpacks/staticfile/index.html#authentication")
+		sf.Log.Protip("Learn about basic authentication", "https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#authentication")
 	}
 
 	return nil


### PR DESCRIPTION
This is a simple change to ensure *.cloudfoundry.org links go to HTTPS instead of HTTP. I don't know why they're not automatically redirected.