### PR TITLE
Fixes #118 : Fizes issue in running tests on MacOS

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -2,7 +2,16 @@
 set -euo pipefail
 set -x
 
-export ROOT=$(dirname $(readlink -f ${BASH_SOURCE%/*}))
+unamestr=`uname`
+# checks rhe operating system to issue readlink on Linux and 
+# stat command on Mac OS.
+if [[ "$unamestr" == 'Linux' ]]; then
+	readlinkalias='readlink '
+elif [[ "$unamestr" == 'Darwin' ]]; then
+        readlinkalias='stat '
+fi
+
+export ROOT=$(dirname $($readlinkalias -f ${BASH_SOURCE%/*}))
 if [ ! -f "$ROOT/.bin/ginkgo" ]; then
   (cd "$ROOT/src/staticfile/vendor/github.com/onsi/ginkgo/ginkgo/" && go install)
 fi

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
+unamestr=`uname`
+# checks rhe operating system to issue readlink on Linux and 
+# stat command on Mac OS.
+if [[ "$unamestr" == 'Linux' ]]; then
+        readlinkalias='readlink '
+elif [[ "$unamestr" == 'Darwin' ]]; then
+        readlinkalias='stat '
+fi
 
-export ROOT=`dirname $(readlink -f ${BASH_SOURCE%/*})`
+export ROOT=`dirname $($readlinkalias -f ${BASH_SOURCE%/*})`
 if [ ! -f $ROOT/.bin/ginkgo ]; then
   (cd $ROOT/src/staticfile/vendor/github.com/onsi/ginkgo/ginkgo/ && go install)
 fi


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Added a change which runs readlink/stat command based on which OS it is running on.
Earlier on Mac readlink was failing.

* An explanation of the use cases your change solves
integration and unit tests can be run using a Mac OS

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have added an integration test