### PR TITLE
fix fixtures/with_https_in_staticfile

### DIFF
--- a/fixtures/with_https_in_staticfile/manifest.yml
+++ b/fixtures/with_https_in_staticfile/manifest.yml
@@ -1,3 +1,0 @@
----
-env:
-  FORCE_HTTPS: true


### PR DESCRIPTION
* A short explanation of the proposed change:
Remove `fixtures/with_https_in_staticfile/manifest.yml`.

* An explanation of the use cases your change solves
This test fixture is for making sure that the configuration in the `Staticfile`  forces https. 
But the environment variable `FORCE_HTTPS: true` in the `manifest.yml` can also force https. The test fixture is in ` fixtures/with_https`.
So removing the `manifest.yml`, this test fixture will be meaningful.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch
