### PR TITLE
Some additions to the Dynatrace extension

### DIFF
--- a/src/staticfile/hooks/dynatrace.go
+++ b/src/staticfile/hooks/dynatrace.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+	"math"
 
 	"github.com/cloudfoundry/libbuildpack"
 )
@@ -38,31 +40,29 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 
 	credentials := h.dtCredentials()
 	if credentials == nil {
-		h.Log.Debug("Dynatrace service not found!")
+		h.Log.Debug("Dynatrace service credentials not found!")
 		return nil
 	}
 
-	h.Log.Info("Dynatrace service found. Setting up Dynatrace PaaS agent.")
+	h.Log.Info("Dynatrace service credentials found. Setting up Dynatrace PaaS agent.")
+
+	skipErrors := credentials["skiperrors"]
 
 	apiurl, present := credentials["apiurl"]
-	if !present && credentials["environmentid"] != "" {
+	if !present {
 		apiurl = "https://" + credentials["environmentid"] + ".live.dynatrace.com/api"
 	}
 
-	if apiurl == "" {
-		return errors.New("'environmentid' or 'apiurl' has to be specified in the service credentials!")
-	}
-
-	if credentials["apitoken"] == "" {
-		return errors.New("'apitoken' has to be specified in the service credentials!")
-	}
-
-	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nginx&bitness=64&Api-Token=" + credentials["apitoken"]
+	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nginx&include=process&bitness=64&Api-Token=" + credentials["apitoken"]
 	installerPath := filepath.Join(os.TempDir(), "paasInstaller.sh")
 
 	h.Log.Debug("Downloading '%s' to '%s'", url, installerPath)
 	err := h.downloadFile(url, installerPath)
 	if err != nil {
+		if skipErrors == "true" {
+			h.Log.Warning("Error during installer download, skipping installation")
+			return nil
+		}
 		return err
 	}
 
@@ -83,19 +83,26 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	h.Log.Info("Dynatrace PaaS agent installed.")
 
 	dynatraceEnvName := "dynatrace-env.sh"
-	installDir := filepath.Join(stager.BuildDir(), "dynatrace", "oneagent")
+	installDir := filepath.Join("dynatrace", "oneagent")
 	dynatraceEnvPath := filepath.Join(stager.DepDir(), "profile.d", dynatraceEnvName)
-	agentLibPath := "dynatrace/oneagent/agent/lib64/liboneagentproc.so"
+	agentLibPath, err := h.agentPath(filepath.Join(stager.BuildDir(), installDir))
+	if err != nil {
+		h.Log.Error("Manifest handling failed!")
+		return err
+	}
 
-	_, err = os.Stat(filepath.Join(stager.BuildDir(), agentLibPath))
+	agentLibPath = filepath.Join(installDir, agentLibPath)
+	agentBuilderLibPath := filepath.Join(stager.BuildDir(), agentLibPath)
+
+	_, err = os.Stat(agentBuilderLibPath)
 	if os.IsNotExist(err) {
-		h.Log.Error("Agent library (%s) not found!", agentLibPath)
+		h.Log.Error("Agent library (%s) not found!", agentBuilderLibPath)
 		return err
 	}
 
 	h.Log.BeginStep("Setting up Dynatrace PaaS agent injection...")
 	h.Log.Debug("Copy %s to %s", dynatraceEnvName, dynatraceEnvPath)
-	err = libbuildpack.CopyFile(filepath.Join(installDir, dynatraceEnvName), dynatraceEnvPath)
+	err = libbuildpack.CopyFile(filepath.Join(stager.BuildDir(), installDir, dynatraceEnvName), dynatraceEnvPath)
 	if err != nil {
 		return err
 	}
@@ -108,16 +115,24 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 
 	defer f.Close()
 
-	h.Log.Debug("Write LD_PRELOAD...")
+	h.Log.Debug("Setting LD_PRELOAD ...")
 	_, err = f.WriteString("\nexport LD_PRELOAD=${HOME}/" + agentLibPath)
 	if err != nil {
 		return err
 	}
 
-	h.Log.Debug("Write DT_HOST_ID...")
+	h.Log.Debug("Setting DT_HOST_ID...")
 	_, err = f.WriteString("\nexport DT_HOST_ID=" + h.appName() + "_${CF_INSTANCE_INDEX}")
 	if err != nil {
 		return err
+	}
+
+	if os.Getenv("DT_LOGSTREAM") == "" {
+		h.Log.Debug("Setting DT_LOGSTREAM to stdout...")
+		_, err = f.WriteString("\nexport DT_LOGSTREAM=stdout")
+		if err != nil {
+			return err
+		}
 	}
 
 	h.Log.Info("Dynatrace PaaS agent injection is set up.")
@@ -126,21 +141,34 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 }
 
 func (h DynatraceHook) dtCredentials() map[string]string {
-	var vcapServices map[string][]struct {
+	type Service struct {
 		Name        string            `json:"name"`
 		Credentials map[string]string `json:"credentials"`
 	}
+	var vcapServices map[string][]Service
+
 	err := json.Unmarshal([]byte(os.Getenv("VCAP_SERVICES")), &vcapServices)
 	if err != nil {
 		return nil
 	}
 
+	var detectedServices []Service
+
 	for _, services := range vcapServices {
 		for _, service := range services {
-			if strings.Contains(service.Name, "dynatrace") {
-				return service.Credentials
+			if strings.Contains(service.Name, "dynatrace") &&
+					service.Credentials["environmentid"] != "" &&
+					service.Credentials["apitoken"] != "" {
+				detectedServices = append(detectedServices, service)
 			}
 		}
+	}
+
+	if len(detectedServices) == 1 {
+		h.Log.Debug("Found one matching service: %s", detectedServices[0].Name)
+		return detectedServices[0].Credentials
+	} else if len(detectedServices) > 1 {
+		h.Log.Warning("More than one matching service found!")
 	}
 
 	return nil
@@ -166,21 +194,84 @@ func (h DynatraceHook) downloadFile(url, path string) error {
 
 	defer out.Close()
 
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
+	baseWaitTime := 3.0
+	for retries := 0.0; retries <= 3.0; retries++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		_, err = io.Copy(out, resp.Body)
+
+		if resp.StatusCode < 400 && err == nil {
+			break
+		} else if (resp.StatusCode >= 400 || err != nil) && retries < 3 {
+			waitTime := time.Duration(baseWaitTime + math.Pow(2, retries))
+			h.Log.Warning("Error during installer download, retrying in %d seconds", waitTime)
+			time.Sleep(waitTime * time.Second)
+			continue
+		} else if (resp.StatusCode >= 400 || err != nil) && retries >= 3 {
+			responseError := "Download returned with status " + resp.Status
+			h.Log.Debug(responseError)
+			return errors.New(responseError)
+		}
 	}
-
-	if resp.StatusCode != 200 {
-		return errors.New("Download returned with status " + resp.Status)
-	}
-
-	defer resp.Body.Close()
-
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func (h DynatraceHook) agentPath(installDir string) (string, error) {
+	manifestPath := filepath.Join(installDir, "manifest.json")
+
+	type Binary struct {
+		Path string `json:"path"`
+		Md5 string `json:"md5"`
+		Version string `json:"version"`
+		Binarytype string `json:"binarytype,omitempty"`
+	}
+
+	type Architecture map[string][]Binary
+	type Technologies map[string]Architecture
+
+	type Manifest struct {
+		Tech Technologies`json:"technologies"`
+		Ver string `json:"version"`
+	}
+
+	var manifest Manifest
+
+	_, err := os.Stat(manifestPath)
+	if  !os.IsNotExist(err) {
+		raw, err := ioutil.ReadFile(manifestPath)
+		if err != nil {
+			return "", err
+		}
+
+		err = json.Unmarshal(raw, &manifest)
+		if err != nil {
+			return "", err
+		}
+
+		var bin_type string
+		for _, binary := range manifest.Tech["process"]["linux-x86-64"] {
+			if binary.Binarytype ==	"primary" {
+				return binary.Path, nil
+			} else {
+				bin_type = binary.Binarytype
+			}
+		}
+
+		if bin_type != "primary" {
+			// using fallback path
+			h.Log.Warning("Agent path not found in manifest.json, using fallback!")
+			fallbackPath := filepath.Join("agent", "lib64", "liboneagentproc.so")
+			return fallbackPath, nil
+		}
+		return "", errors.New("No primary binary for process agent found!")
+	} else {
+		h.Log.Info("manifest.json not found, using fallback!")
+		fallbackPath := filepath.Join("agent", "lib64", "liboneagentproc.so")
+		return fallbackPath, nil
+	}
 }

--- a/src/staticfile/integration/deploy_app_with_dynatrace_test.go
+++ b/src/staticfile/integration/deploy_app_with_dynatrace_test.go
@@ -1,0 +1,175 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"os/exec"
+
+	"github.com/cloudfoundry/libbuildpack/cutlass"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CF Statifile Buildpack", func() {
+	var app *cutlass.App
+	var createdServices []string
+	AfterEach(func() {
+		if app != nil {
+			app.Destroy()
+		}
+		app = nil
+
+		for _, service := range createdServices {
+			command := exec.Command("cf", "delete-service", "-f", service)
+			_, err := command.Output()
+			Expect(err).To(BeNil())
+		}
+	})
+
+	BeforeEach(func() {
+		app = cutlass.New(filepath.Join(bpDir, "fixtures", "logenv"))
+		app.SetEnv("BP_DEBUG", "true")
+		PushAppAndConfirm(app)
+
+		createdServices = make([]string, 0)
+	})
+
+	Context("deploying a staticfile app with Dynatrace agent with single credentials service", func() {
+		It("checks if Dynatrace injection was successful", func() {
+
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", serviceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas/manifest\",\"environmentid\":\"envid\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, serviceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace PaaS agent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace PaaS agent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent injection is set up."))
+		})
+	})
+
+	Context("deploying a staticfile app with Dynatrace agent with two credentials services", func() {
+		It("checks if detection of second service with credentials works", func() {
+
+			CredentialsServiceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", CredentialsServiceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas/manifest\",\"environmentid\":\"envid\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, CredentialsServiceName)
+
+			duplicateCredentialsServiceName := "dynatrace-dupe-" + cutlass.RandStringRunes(20) + "-service"
+			command = exec.Command("cf", "cups", duplicateCredentialsServiceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas/manifest\",\"environmentid\":\"envid\"}'")
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, duplicateCredentialsServiceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, CredentialsServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "bind-service", app.Name, duplicateCredentialsServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.Stdout.String()).To(ContainSubstring("More than one matching service found!"))
+		})
+	})
+
+	Context("deploying a staticfile app with Dynatrace agent with failing agent download and ignoring errors", func() {
+		It("checks if skipping download errors works", func() {
+
+			CredentialsServiceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", CredentialsServiceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paasFAILING/manifest\",\"environmentid\":\"envid\",\"skiperrors\":\"true\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, CredentialsServiceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, CredentialsServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.Stdout.String()).To(ContainSubstring("Error during installer download, skipping installation"))
+		})
+	})
+	Context("deploying a staticfile app with Dynatrace agent with two dynatrace services", func() {
+		It("check if service detection isn't disturbed by a service with tags", func() {
+
+			CredentialsServiceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", CredentialsServiceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas/manifest\",\"environmentid\":\"envid\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, CredentialsServiceName)
+
+			tagsServiceName := "dynatrace-tags-" + cutlass.RandStringRunes(20) + "-service"
+			command = exec.Command("cf", "cups", tagsServiceName, "-p", "'{\"tag:dttest\":\"dynatrace_test\"}'")
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, tagsServiceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, CredentialsServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "bind-service", app.Name, tagsServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace PaaS agent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace PaaS agent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent injection is set up."))
+
+			//Expect(app.GetBody("/")).To(ContainSubstring("\"DT_HOST_ID\":\"" + app.Name + "_0\""))
+		})
+	})
+
+	Context("deploying a staticfile app with Dynatrace agent with single credentials service and without manifest.json", func() {
+		It("checks if Dynatrace injection was successful", func() {
+
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", serviceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas\",\"environmentid\":\"envid\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, serviceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace PaaS agent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace PaaS agent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent injection is set up."))
+		})
+	})
+
+})
+


### PR DESCRIPTION
* A short explanation of the proposed change:
Added a bunch of things to the Dynatrace extension:

* detection if there is more than one credential service, if yes: fail, since that is not supported.
* download retry: failed installer downloads retry 3 times with exponential backoff. This should help prevent issues with mass deployments and download throttling.
* skiperrors flag: gives the user/customer the option to ignore errors from the installer download. It will then just skip the rest of the steps after the download and the overall app deployment doesn't fail. This is a request we had from various customers to prevent failing app deployments in case of small network hickups or throttling issues.
* the path to the agent binary is now taken from the manifest.json file instead of being hardcoded into the extension. This makes it failsafer and future changes in filepaths do not require changes to the buildpack-extension anymore.
* default for environment variable DT_LOGSTREAM added. If the user/customer doesn't set the variable, we set it to 'stdout'.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
