### PR TITLE
fixed bug with json handling in credentials in dynatrace hook

### DIFF
--- a/src/staticfile/hooks/dynatrace.go
+++ b/src/staticfile/hooks/dynatrace.go
@@ -19,6 +19,14 @@ type Command interface {
 	Execute(string, io.Writer, io.Writer, string, ...string) error
 }
 
+type DynatraceCredentials struct {
+	ServiceName string
+	EnvironmentId string
+	ApiToken string
+	ApiURL string
+	SkipErrors bool
+}
+
 type DynatraceHook struct {
 	libbuildpack.DefaultHook
 	Log             *libbuildpack.Logger
@@ -40,28 +48,26 @@ func init() {
 func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	h.Log.Debug("Checking for enabled dynatrace service...")
 
-	credentials := h.dtCredentials()
-	if credentials == nil {
+	credentials, found := h.dtCredentials()
+	if !found {
 		h.Log.Debug("Dynatrace service credentials not found!")
 		return nil
 	}
 
 	h.Log.Info("Dynatrace service credentials found. Setting up Dynatrace PaaS agent.")
 
-	skipErrors := credentials["skiperrors"]
-
-	apiurl, present := credentials["apiurl"]
-	if !present {
-		apiurl = "https://" + credentials["environmentid"] + ".live.dynatrace.com/api"
+	apiurl := credentials.ApiURL
+	if apiurl == "" {
+		apiurl = "https://" + credentials.EnvironmentId + ".live.dynatrace.com/api"
 	}
 
-	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nginx&include=process&bitness=64&Api-Token=" + credentials["apitoken"]
+	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nginx&include=process&bitness=64&Api-Token=" + credentials.ApiToken
 	installerPath := filepath.Join(os.TempDir(), "paasInstaller.sh")
 
 	h.Log.Debug("Downloading '%s' to '%s'", url, installerPath)
 	err := h.downloadFile(url, installerPath)
 	if err != nil {
-		if skipErrors == "true" {
+		if credentials.SkipErrors {
 			h.Log.Warning("Error during installer download, skipping installation")
 			return nil
 		}
@@ -142,38 +148,57 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	return nil
 }
 
-func (h DynatraceHook) dtCredentials() map[string]string {
-	type Service struct {
-		Name        string            `json:"name"`
-		Credentials map[string]string `json:"credentials"`
+func (h DynatraceHook) getCredentialString(credentials map[string]interface{}, key string) string {
+	value, isString := credentials[key].(string)
+
+	if isString {
+		return value
 	}
+	return ""
+}
+
+func (h DynatraceHook) dtCredentials() (DynatraceCredentials, bool) {
+	type Service struct {
+		Name        string                 `json:"name"`
+		Credentials map[string]interface{} `json:"credentials"`
+	}
+
 	var vcapServices map[string][]Service
 
 	err := json.Unmarshal([]byte(os.Getenv("VCAP_SERVICES")), &vcapServices)
 	if err != nil {
-		return nil
+		h.Log.Debug("Failed to unmarshal VCAP_SERVICES: %s", err)
+		return DynatraceCredentials{}, false
 	}
 
-	var detectedServices []Service
+	var detectedCredentials []DynatraceCredentials
 
 	for _, services := range vcapServices {
 		for _, service := range services {
-			if strings.Contains(service.Name, "dynatrace") &&
-				service.Credentials["environmentid"] != "" &&
-				service.Credentials["apitoken"] != "" {
-				detectedServices = append(detectedServices, service)
+			if strings.Contains(service.Name, "dynatrace") {
+				credentials := DynatraceCredentials{
+					ServiceName :   service.Name,
+					EnvironmentId : h.getCredentialString(service.Credentials, "environmentid"),
+					ApiToken :      h.getCredentialString(service.Credentials, "apitoken"),
+					ApiURL :        h.getCredentialString(service.Credentials, "apiurl"),
+					SkipErrors :    h.getCredentialString(service.Credentials, "skiperrors") == "true",
+				}
+
+				if credentials.EnvironmentId != "" && credentials.ApiToken != "" {
+					detectedCredentials = append(detectedCredentials, credentials)
+				}
 			}
 		}
 	}
 
-	if len(detectedServices) == 1 {
-		h.Log.Debug("Found one matching service: %s", detectedServices[0].Name)
-		return detectedServices[0].Credentials
-	} else if len(detectedServices) > 1 {
+	if len(detectedCredentials) == 1 {
+		h.Log.Debug("Found one matching service: %s", detectedCredentials[0].ServiceName)
+		return detectedCredentials[0], true
+	} else if len(detectedCredentials) > 1 {
 		h.Log.Warning("More than one matching service found!")
 	}
 
-	return nil
+	return DynatraceCredentials{}, false
 }
 
 func (h DynatraceHook) appName() string {


### PR DESCRIPTION
* A short explanation of the proposed change:

Fixed a bug where our installer wasn't started when there was a service bound that had a JSON object in the credentials.

* An explanation of the use cases your change solves

Before, we only looked for key-value-pairs in the credentials of services, which resulted in an unmarshaling error when there was anything else in there, eg. a JSON object.
Adapted the credentials checking and extraction to make it a bit more general and forgiving in that regard.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
