### PR TITLE
Preserves x_forwarded_host on https

### DIFF
--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -79,27 +79,27 @@ http {
 
     root <%= ENV["APP_ROOT"] %>/public;
 
-   {{if .ForceHTTPS}}
-	 set $updated_host $host;
-	 if ($http_x_forwarded_host != "") {
-       set $updated_host $http_x_forwarded_host;
-     } 
+    {{if .ForceHTTPS}}
+      set $updated_host $host;
+      if ($http_x_forwarded_host != "") {
+        set $updated_host $http_x_forwarded_host;
+      } 
 
-     if ($http_x_forwarded_proto != "https") {
-	   return 301 https://$updated_host$request_uri;
-	 }
-   {{else}}
-	<% if ENV["FORCE_HTTPS"] %>
-	 set $updated_host $host;
-	 if ($http_x_forwarded_host != "") {
-       set $updated_host $http_x_forwarded_host;
-     } 
+      if ($http_x_forwarded_proto != "https") {
+        return 301 https://$updated_host$request_uri;
+      }
+    {{else}}
+      <% if ENV["FORCE_HTTPS"] %>
+        set $updated_host $host;
+        if ($http_x_forwarded_host != "") {
+          set $updated_host $http_x_forwarded_host;
+        } 
 
-     if ($http_x_forwarded_proto != "https") {
-	   return 301 https://$updated_host$request_uri;
-	 }
-	<% end %>
-   {{end}}
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$updated_host$request_uri;
+        }
+      <% end %>
+    {{end}}
 
 
     location / {

--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -80,15 +80,25 @@ http {
     root <%= ENV["APP_ROOT"] %>/public;
 
    {{if .ForceHTTPS}}
+	 set $updated_host $host;
+	 if ($http_x_forwarded_host != "") {
+       set $updated_host $http_x_forwarded_host;
+     } 
+
      if ($http_x_forwarded_proto != "https") {
-       return 301 https://$host$request_uri;
-     }
+	   return 301 https://$updated_host$request_uri;
+	 }
    {{else}}
-   <% if ENV["FORCE_HTTPS"] %>
+	<% if ENV["FORCE_HTTPS"] %>
+	 set $updated_host $host;
+	 if ($http_x_forwarded_host != "") {
+       set $updated_host $http_x_forwarded_host;
+     } 
+
      if ($http_x_forwarded_proto != "https") {
-       return 301 https://$host$request_uri;
-     }
-   <% end %>
+	   return 301 https://$updated_host$request_uri;
+	 }
+	<% end %>
    {{end}}
 
 

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -595,15 +595,25 @@ var _ = Describe("Compile", func() {
         }
 			`)
 			forceHTTPSConf := stripStartWsp(`
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
+				set $updated_host $host;
+				if ($http_x_forwarded_host != "") {
+       				set $updated_host $http_x_forwarded_host;
+				} 
+
+				if ($http_x_forwarded_proto != "https") {
+					return 301 https://$updated_host$request_uri;
+				}
 			`)
 			forceHTTPSErb := stripStartWsp(`
 				<% if ENV["FORCE_HTTPS"] %>
-					if ($http_x_forwarded_proto != "https") {
-						return 301 https://$host$request_uri;
-					}
+				set $updated_host $host;
+				if ($http_x_forwarded_host != "") {
+					set $updated_host $http_x_forwarded_host;
+				} 
+			
+				if ($http_x_forwarded_proto != "https") {
+					return 301 https://$updated_host$request_uri;
+				}
 				<% end %>
 			`)
 			basicAuthConf := stripStartWsp(`

--- a/src/staticfile/integration/deploy_https_redirect_test.go
+++ b/src/staticfile/integration/deploy_https_redirect_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"fmt"
 )
 
 var _ = Describe("deploy a staticfile app", func() {
@@ -34,6 +35,14 @@ var _ = Describe("deploy a staticfile app", func() {
 			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
 			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix("https://"))))
 		})
+
+		It("injects x-forwarded-host into Location on redirect", func() {
+			var upstreamHostName = "upstreamHostName.com"
+			_, headers, err := app.Get("/", map[string]string{"NoFollow": "true", "X-Forwarded-Host": upstreamHostName})
+			Expect(err).To(BeNil())
+			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
+			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix(fmt.Sprintf("https://%s", upstreamHostName)))))
+		})
 	})
 
 	Context("Using Staticfile", func() {
@@ -45,5 +54,14 @@ var _ = Describe("deploy a staticfile app", func() {
 			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
 			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix("https://"))))
 		})
+
+		It("injects x-forwarded-host into Location on redirect", func() {
+			var upstreamHostName = "upstreamHostName.com"
+			_, headers, err := app.Get("/", map[string]string{"NoFollow": "true", "X-Forwarded-Host": upstreamHostName})
+			Expect(err).To(BeNil())
+			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
+			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix(fmt.Sprintf("https://%s", upstreamHostName)))))
+		})
+
 	})
 })


### PR DESCRIPTION
Closes #141. Updates .ForceHTTPS block to preserve the
x-forwarded-host on https redirects.

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Updates `src/finalize/data.go` .ForceHTTPS block to preserve `X-Forwarded-Host` on https redirect.

* An explanation of the use cases your change solves
If an app is behind a CNAME, the https redirect should preserve that CNAME. 

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test

I wasn't sure whether to add logic to the existing force_https integration test or create a new one. 