### PR TITLE
Serve .js files as application/javascript

### DIFF
--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -153,7 +153,7 @@ types {
   text/xml xml;
   image/gif gif;
   image/jpeg jpeg jpg;
-  application/x-javascript js;
+  application/javascript js;
   application/atom+xml atom;
   application/rss+xml rss;
   font/ttf ttf;


### PR DESCRIPTION
* A short explanation of the proposed change:

According to [RFC 4329](https://tools.ietf.org/html/rfc4329#section-3) the use of the `application/x-javascript` is discouraged.  The recommended media type is `application/javascript`.

* An explanation of the use cases your change solves

Some software packages are fussy about the media types that they accept for javascript.  We hit an issue where the react native script loader [doesn't support](https://github.com/facebook/react-native/blob/7d4e94edccfc2f642fcbd1d6aa00756f02e3a525/React/Base/RCTJavaScriptLoader.mm#L287-L299) javascript files with `application/x-javascript`. 

* [x] I have viewed signed and have submitted the Contributor License Agreement

I have followed the IBM process for contributing to cloud foundry.

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test

I couldn't see any integration tests for this kind of functionality.  If one is required I can create it.