### PR TITLE
Convert tabs to spaces in template, which is space-indented

### DIFF
--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -133,9 +133,9 @@ http {
         include {{.LocationInclude}};
       {{end}}
 
-			{{ range $code, $value := .StatusCodes }}
-			  error_page {{ $code }} {{ $value }};
-		  {{ end }}
+      {{ range $code, $value := .StatusCodes }}
+        error_page {{ $code }} {{ $value }};
+      {{ end }}
     }
 
     {{if not .HostDotFiles}}


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Convert tabs to space in `nginxConfTemplate`, which is space-indented.

* An explanation of the use cases your change solves

N.A.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* ~[ ] I have added an integration test~ none added, as this does not change functionality.
