### PR TITLE
Updating version for nginx-static for 1.19.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,13 +5,13 @@ default_versions:
   version: 1.19.x
 dependencies:
 - name: nginx
-  version: 1.19.5
-  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.19.5_linux_x64_cflinuxfs3_1bd9c579.tgz
-  sha256: 1bd9c579322300fb5164d0c1baae6ffbb9aac6712fec6d51723a35992773be26
+  version: 1.19.6
+  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.19.6_linux_x64_cflinuxfs3_aa3d3d5b.tgz
+  sha256: aa3d3d5beee6c5ffbea5b9c098f389943585dcca91b07eb68ae75847408e905d
   cf_stacks:
   - cflinuxfs3
-  source: http://nginx.org/download/nginx-1.19.5.tar.gz
-  source_sha256: 5c0a46afd6c452d4443f6ec0767f4d5c3e7c499e55a60cd6542b35a61eda799c
+  source: http://nginx.org/download/nginx-1.19.6.tar.gz
+  source_sha256: b11195a02b1d3285ddf2987e02c6b6d28df41bb1b1dd25f33542848ef4fc33b5
 pre_package: scripts/build.sh
 include_files:
 - CHANGELOG


### PR DESCRIPTION
This PR is made automatically by release engineering bot.