### PR TITLE
Updating version for nginx-static for 1.19.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,13 +5,13 @@ default_versions:
   version: 1.19.x
 dependencies:
 - name: nginx
-  version: 1.19.9
-  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.19.9_linux_x64_cflinuxfs3_f20d9496.tgz
-  sha256: f20d9496b9621debf81eda09458756446f770acb896ebf420d9cc954acb88223
+  version: 1.19.10
+  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.19.10_linux_x64_cflinuxfs3_109f725d.tgz
+  sha256: 109f725dd06831fcab2510c7cfdf251dde2d691e1f2ba7ef55afbecb8af63d24
   cf_stacks:
   - cflinuxfs3
-  source: http://nginx.org/download/nginx-1.19.9.tar.gz
-  source_sha256: 2e35dff06a9826e8aca940e9e8be46b7e4b12c19a48d55bfc2dc28fc9cc7d841
+  source: http://nginx.org/download/nginx-1.19.10.tar.gz
+  source_sha256: e8d0290ff561986ad7cd6c33307e12e11b137186c4403a6a5ccdb4914c082d88
 pre_package: scripts/build.sh
 include_files:
 - CHANGELOG


### PR DESCRIPTION
This PR is made automatically by release engineering bot.