### PR TITLE
bumped libbuildpack-dynatrace to v1.4.0 and update integration tests …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudfoundry/staticfile-buildpack
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.3.0
+	github.com/Dynatrace/libbuildpack-dynatrace v1.4.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20210615150252-561bcf1024cf
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Dynatrace/libbuildpack-dynatrace v1.3.0 h1:Gr3npoRtYUe4U+4V2vwAW1TiEcFckMHeYlkguVSnnCU=
 github.com/Dynatrace/libbuildpack-dynatrace v1.3.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.0 h1:4zvEFkyR8rlH+UbH1WQpo74cTFT3DpPsklJiQdGmpNU=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=


### PR DESCRIPTION
* A short explanation of the proposed change:
bumped libbuildpack-dynatrace to v1.4.0 and updated integration tests with networkzones
* An explanation of the use cases your change solves
The `networkzone` property is now also used when downloading the Dynatrace OneAgent from the API
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
