### PR TITLE
Add Configurable HTTP/2 Support

### DIFF
--- a/fixtures/enable_http2/index.html
+++ b/fixtures/enable_http2/index.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <p>
+      This is an example app for Cloud Foundry that is only static HTML/JS/CSS assets.
+    </p>
+  </body>
+</html>

--- a/fixtures/enable_http2/v3-manifest.yml
+++ b/fixtures/enable_http2/v3-manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: SED_APP_NAME
+  routes:
+    - route: SED_ROUTE
+      protocol: http2
+  env:
+    ENABLE_HTTP2: true

--- a/fixtures/enable_http2_in_staticfile/Staticfile
+++ b/fixtures/enable_http2_in_staticfile/Staticfile
@@ -1,0 +1,1 @@
+enable_http2: enabled

--- a/fixtures/enable_http2_in_staticfile/index.html
+++ b/fixtures/enable_http2_in_staticfile/index.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Static file demo app</title>
+  </head>
+  <body>
+    <p>
+      This is an example app for Cloud Foundry that is only static HTML/JS/CSS assets.
+    </p>
+  </body>
+</html>

--- a/fixtures/enable_http2_in_staticfile/v3-manifest.yml
+++ b/fixtures/enable_http2_in_staticfile/v3-manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: SED_APP_NAME
+  routes:
+    - route: SED_ROUTE
+      protocol: http2

--- a/src/staticfile/finalize/data.go
+++ b/src/staticfile/finalize/data.go
@@ -74,7 +74,15 @@ http {
   server_tokens off;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    {{if .EnableHttp2}}
+	  listen <%= ENV["PORT"] %> http2;
+    {{else}}
+      <% if ENV["ENABLE_HTTP2"] %>
+	    listen <%= ENV["PORT"] %> http2;
+      <% else %>
+	    listen <%= ENV["PORT"] %>;
+      <% end %>
+    {{end}}
     server_name localhost;
 
     root <%= ENV["APP_ROOT"] %>/public;

--- a/src/staticfile/finalize/finalize.go
+++ b/src/staticfile/finalize/finalize.go
@@ -24,6 +24,7 @@ type Staticfile struct {
 	HSTSIncludeSubDomains bool   `yaml:"http_strict_transport_security_include_subdomains"`
 	HSTSPreload           bool   `yaml:"http_strict_transport_security_preload"`
 	ForceHTTPS            bool   `yaml:"force_https"`
+	EnableHttp2           bool   `yaml:"enable_http2"`
 	BasicAuth             bool
 	StatusCodes           map[string]string `yaml:"status_codes"`
 }
@@ -50,6 +51,7 @@ type StaticfileTemp struct {
 	HSTSIncludeSubDomains string            `yaml:"http_strict_transport_security_include_subdomains"`
 	HSTSPreload           string            `yaml:"http_strict_transport_security_preload"`
 	ForceHTTPS            string            `yaml:"force_https"`
+	EnableHttp2           string            `yaml:"enable_http2"`
 	StatusCodes           map[string]string `yaml:"status_codes"`
 }
 
@@ -175,6 +177,10 @@ func (sf *Finalizer) LoadStaticfile() error {
 	if isEnabled(hash.HSTSPreload) {
 		sf.Log.BeginStep("Enabling HSTS Preload")
 		conf.HSTSPreload = true
+	}
+	if isEnabled(hash.EnableHttp2) {
+		sf.Log.BeginStep("Enabling HTTP/2")
+		conf.EnableHttp2 = true
 	}
 	if isEnabled(hash.ForceHTTPS) {
 		sf.Log.BeginStep("Enabling HTTPS redirect")

--- a/src/staticfile/integration/deploy_enable_http2_test.go
+++ b/src/staticfile/integration/deploy_enable_http2_test.go
@@ -1,0 +1,124 @@
+package integration_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/cloudfoundry/libbuildpack/cutlass"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("deploy a HTTP/2 app", func() {
+	var app *cutlass.App
+	var app_name string
+	AfterEach(func() {
+		if app != nil {
+			app.Destroy()
+		}
+		app = nil
+		app_name = ""
+	})
+
+	BeforeEach(func() {
+		apiVersionString, err := cutlass.ApiVersion()
+		Expect(err).To(BeNil())
+		apiVersion, err := semver.Make(apiVersionString)
+		Expect(err).To(BeNil())
+		apiHasHttp2, err := semver.ParseRange("> 2.172.0")
+		Expect(err).To(BeNil())
+		if !apiHasHttp2(apiVersion) {
+			Skip("HTTP/2 not supported for this API version.")
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(app_name).ToNot(BeEmpty())
+		app = cutlass.New(Fixtures(app_name))
+		PushAppAndConfirm(app)
+
+		By("inserting the app name and default route into the manifest with HTTP/2 configuration")
+		manifestPath := filepath.Join(app.Path, "v3-manifest.yml")
+		manifestTemplate, err := ioutil.ReadFile(manifestPath)
+		Expect(err).To(BeNil())
+
+		appName := app.Name
+		appRoute, err := app.GetUrl("")
+		Expect(err).To(BeNil())
+
+		manifestBody := strings.ReplaceAll(string(manifestTemplate), "SED_APP_NAME", appName)
+		manifestBody = strings.ReplaceAll(manifestBody, "SED_ROUTE", appRoute)
+
+		By("applying manifest to set http2 protocol on route")
+		err = v3ApplyManifest(app, manifestBody)
+		Expect(err).To(BeNil())
+	})
+
+	Context("Using ENV Variable", func() {
+		BeforeEach(func() { app_name = "enable_http2" })
+
+		It("serves HTTP/2 traffic", func() {
+			By("ensuring that the manifest background job has set the env variable", func() {
+				runEnvCommand := func() string {
+					envCommand := exec.Command("cf", "env", app.Name)
+					output, err := envCommand.Output()
+					Expect(err).To(BeNil())
+
+					return string(output)
+				}
+				Eventually(runEnvCommand).Should(ContainSubstring("ENABLE_HTTP2"))
+			})
+
+			By("restarting the app to apply the environment variable change", func() {
+				Expect(app.Restart()).To(Succeed())
+				Eventually(app.InstanceStates).Should(Equal([]string{"RUNNING"}))
+			})
+
+			_, headers, err := app.Get("/", map[string]string{})
+			Expect(err).To(BeNil())
+			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"200"}))
+		})
+	})
+
+	Context("Using Staticfile", func() {
+		BeforeEach(func() { app_name = "enable_http2_in_staticfile" })
+
+		It("serves HTTP/2 traffic", func() {
+			getAppRoot := func() map[string][]string {
+				_, headers, err := app.Get("/", map[string]string{})
+				Expect(err).To(BeNil())
+				return headers
+			}
+			By("polling the app until the HTTP/2 route configuration has propogated", func() {
+				Eventually(getAppRoot).Should(HaveKeyWithValue("StatusCode", []string{"200"}))
+			})
+		})
+	})
+})
+
+func v3ApplyManifest(a *cutlass.App, manifestBody string) error {
+	spaceGUID, err := a.SpaceGUID()
+	if err != nil {
+		return err
+	}
+	manifestURL := fmt.Sprintf("/v3/spaces/%s/actions/apply_manifest", spaceGUID)
+	command := exec.Command(
+		"cf", "curl",
+		"-X", "POST",
+		"-H", "Content-Type: application/x-yaml",
+		manifestURL,
+		"-d", manifestBody,
+	)
+	command.Stdout = cutlass.DefaultStdoutStderr
+	command.Stderr = cutlass.DefaultStdoutStderr
+	if err = command.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- nginx can not serve both HTTP/1 and HTTP/2 on the same port, if the
port does not use TLS. See https://trac.nginx.org/nginx/ticket/816.
- Implementation mirrors `force_https` to make it user-configurable
- new staticfile option of `enable_http2` and use of environment
variable `ENABLE_HTTP2` to configure nginx
- Route HTTP/2 configuration is available via manifest when using cf cli
v7 or with the map-route command when using cf cli v8
- since cutlass only supports cf cli v6, testing bypasses cutlass with
"cf curl" commands. These can be replaced with proper cf cli commands
when upgrading the cf cli version
- integration tests only runs on api 2.172.0 or higher

[cloudfoundry/routing-release#200]

Co-authored-by: Michael Oleske <moleske@vmware.com>

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
