### PR TITLE
Handle comma separated X-Forwarded-{Header,Prefix}

### DIFF
--- a/src/staticfile/integration/deploy_https_redirect_test.go
+++ b/src/staticfile/integration/deploy_https_redirect_test.go
@@ -42,6 +42,19 @@ var _ = Describe("deploy a staticfile app", func() {
 			Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
 			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix(fmt.Sprintf("https://%s", upstreamHostName)))))
 		})
+
+		Context("Comma separated values in X-Forwarded headers", func() {
+			It("picks leftmost x-forwarded-host,-port values into Location on redirect", func() {
+				_, headers, err := app.Get("/path1/path2", map[string]string{
+					"NoFollow":           "true",
+					"X-Forwarded-Host":   "host.com, something.else",
+					"X-Forwarded-Prefix": "/pre/fix1, /pre/fix2",
+				})
+				Expect(err).To(BeNil())
+				Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
+				Expect(headers).To(HaveKeyWithValue("Location", ConsistOf("https://host.com/pre/fix1/path1/path2")))
+			})
+		})
 	})
 
 	Context("Using Staticfile", func() {
@@ -62,5 +75,17 @@ var _ = Describe("deploy a staticfile app", func() {
 			Expect(headers).To(HaveKeyWithValue("Location", ConsistOf(HavePrefix(fmt.Sprintf("https://%s", upstreamHostName)))))
 		})
 
+		Context("Comma separated values in X-Forwarded headers", func() {
+			It("picks leftmost x-forwarded-host,-port values into Location on redirect", func() {
+				_, headers, err := app.Get("/path1/path2", map[string]string{
+					"NoFollow":           "true",
+					"X-Forwarded-Host":   "host.com, something.else",
+					"X-Forwarded-Prefix": "/pre/fix1, /pre/fix2",
+				})
+				Expect(err).To(BeNil())
+				Expect(headers).To(HaveKeyWithValue("StatusCode", []string{"301"}))
+				Expect(headers).To(HaveKeyWithValue("Location", ConsistOf("https://host.com/pre/fix1/path1/path2")))
+			})
+		})
 	})
 })


### PR DESCRIPTION
1. Proxies can technically set these headers with multiple comma separated
values. For X-Forwarded-Host header, we were dumping the entire value into the
redirect thus creating invalid redirects like `301 https://host1,
host2`. With this change, we pick the leftmost comma separated value
to use for setting the redirect host location.

2. Add support for X-Forwarded-Prefix
Also in the edge case there are multiple comma separated values,
pick the leftmost.

E.g.

```
X-Forwarded-Host: host1, host2
X-Forwarded-Prefix: /pre/fix1, /pre/fix2
example.com/abc/def
```

will resolve to `301 https://host1/pre/fix1/abc/def`

Fixes #280 