### PR TITLE
Don't use ERB to template nginx.conf

### DIFF
--- a/fixtures/reverse_proxy/nginx.conf
+++ b/fixtures/reverse_proxy/nginx.conf
@@ -1,12 +1,12 @@
 worker_processes 1;
 daemon off;
 
-error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+error_log ((APP_ROOT))/nginx/logs/error.log;
 events { worker_connections 1024; }
 
 http {
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
-  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  access_log ((APP_ROOT))/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;
   include mime.types;
   sendfile on;
@@ -15,7 +15,7 @@ http {
   keepalive_timeout 30;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    listen ((PORT));
     server_name localhost;
 
     location /intl/en/policies {
@@ -23,7 +23,7 @@ http {
     }
 
     location / {
-      root <%= ENV["APP_ROOT"] %>/public;
+      root ((APP_ROOT))/public;
       index index.html index.htm Default.htm;
     }
   }

--- a/src/staticfile/finalize/finalize_test.go
+++ b/src/staticfile/finalize/finalize_test.go
@@ -585,26 +585,12 @@ var _ = Describe("Compile", func() {
         }
 			`)
 			enableHttp2Conf := stripStartWsp(`
-				listen <%= ENV["PORT"] %> http2;
-			`)
-			enableHttp2Erb := stripStartWsp(`
-				<% if ENV["ENABLE_HTTP2"] %>
-				  listen <%= ENV["PORT"] %> http2;
-				<% else %>
-				  listen <%= ENV["PORT"] %>;
-				<% end %>
+				listen ((PORT)) http2;
 			`)
 			forceHTTPSConf := stripStartWsp(`
 				if ($best_proto != "https") {
 					return 301 https://$best_host$best_prefix$request_uri;
 				}
-			`)
-			forceHTTPSErb := stripStartWsp(`
-				<% if ENV["FORCE_HTTPS"] %>
-					if ($best_proto != "https") {
-						return 301 https://$best_host$best_prefix$request_uri;
-					}
-				<% end %>
 			`)
 			xForwardedHostMappingConf := stripStartWsp(`
 				map $http_x_forwarded_host $best_host {
@@ -626,7 +612,7 @@ var _ = Describe("Compile", func() {
 			`)
 			basicAuthConf := stripStartWsp(`
         auth_basic "Restricted";  #For Basic Auth
-        auth_basic_user_file <%= ENV["APP_ROOT"] %>/nginx/conf/.htpasswd;
+        auth_basic_user_file ((APP_ROOT))/nginx/conf/.htpasswd;
 			`)
 
 			Context("host_dot_files is set in staticfile", func() {
@@ -791,7 +777,7 @@ var _ = Describe("Compile", func() {
 				It("the listener uses the http2 directive", func() {
 					data := readNginxConfAndStrip()
 					Expect(string(data)).To(ContainSubstring(enableHttp2Conf))
-					Expect(string(data)).NotTo(ContainSubstring(`<% if ENV["ENABLE_HTTP2"] %>`))
+					Expect(string(data)).NotTo(ContainSubstring(`((LISTEN_DIRECTIVE))`))
 				})
 			})
 
@@ -801,7 +787,7 @@ var _ = Describe("Compile", func() {
 				})
 				It("using the http2 directive depends on ENV['ENABLE_HTTP2']", func() {
 					data := readNginxConfAndStrip()
-					Expect(string(data)).To(ContainSubstring(enableHttp2Erb))
+					Expect(string(data)).To(ContainSubstring(`((LISTEN_DIRECTIVE))`))
 				})
 			})
 
@@ -815,7 +801,6 @@ var _ = Describe("Compile", func() {
 					Expect(string(data)).To(ContainSubstring(xForwardedHostMappingConf))
 					Expect(string(data)).To(ContainSubstring(xForwardedPrefixMappingConf))
 					Expect(string(data)).To(ContainSubstring(xForwardedProtoMappingConf))
-					Expect(string(data)).NotTo(ContainSubstring(`<% if ENV["FORCE_HTTPS"] %>`))
 				})
 			})
 
@@ -825,11 +810,10 @@ var _ = Describe("Compile", func() {
 				})
 				It("the 301 redirect does depend on ENV['FORCE_HTTPS']", func() {
 					data := readNginxConfAndStrip()
-					Expect(string(data)).To(ContainSubstring(forceHTTPSErb))
+					Expect(string(data)).To(ContainSubstring(`((FORCE_HTTPS_DIRECTIVE))`))
 					Expect(string(data)).To(ContainSubstring(xForwardedHostMappingConf))
 					Expect(string(data)).To(ContainSubstring(xForwardedPrefixMappingConf))
 					Expect(string(data)).To(ContainSubstring(xForwardedProtoMappingConf))
-					Expect(string(data)).To(ContainSubstring(`<% if ENV["FORCE_HTTPS"] %>`))
 				})
 			})
 


### PR DESCRIPTION
* A short explanation of the proposed change:
We will no longer use ERB to template out the `nginx.conf` file at runtime.

* An explanation of the use cases your change solves
Resolves #359 

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
