### PR TITLE
Remove dependency credential test

### DIFF
--- a/src/staticfile/brats/brats_test.go
+++ b/src/staticfile/brats/brats_test.go
@@ -8,7 +8,6 @@ import (
 var _ = Describe("Staticfile buildpack", func() {
 	bratshelper.UnbuiltBuildpack("nginx", CopyBrats)
 	bratshelper.DeployingAnAppWithAnUpdatedVersionOfTheSameBuildpack(CopyBrats)
-	bratshelper.StagingWithCustomBuildpackWithCredentialsInDependencies(CopyBrats)
 	bratshelper.DeployAppWithExecutableProfileScript("nginx", CopyBrats)
 	bratshelper.DeployAnAppWithSensitiveEnvironmentVariables(CopyBrats)
 })


### PR DESCRIPTION
- the change in CDN results in these tests failing, because the new CDN config does not support credentials in this way.
- we believe that consumers do not use this feature, as we have not had any reports of this causing failures for consumers.
- if we get reports that consumers cannot download dependencies from the CDN with credentials, and we deem this to be a necessary feature, we can update the CDN config and re-add these tests.

cc @robdimsdale 