### PR TITLE
Remove non-default nginx version line

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,22 +5,6 @@ default_versions:
   version: 1.27.x
 dependencies:
 - name: nginx
-  version: 1.26.3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.26.3_linux_x64_cflinuxfs3_610037dd.tgz
-  sha256: 610037dd277c2341225b4c36b3d5b22a9810c62ddbc1db444ba4167d74b1c9c2
-  cf_stacks:
-  - cflinuxfs3
-  source: http://nginx.org/download/nginx-1.26.3.tar.gz
-  source_sha256: 69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
-- name: nginx
-  version: 1.26.3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.26.3_linux_x64_cflinuxfs4_78ba6963.tgz
-  sha256: 78ba6963f4e77a746547bac843047b50237e3574100cb8da2ca1249a0e814a02
-  cf_stacks:
-  - cflinuxfs4
-  source: http://nginx.org/download/nginx-1.26.3.tar.gz
-  source_sha256: 69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
-- name: nginx
   version: 1.27.4
   uri: https://buildpacks.cloudfoundry.org/dependencies/nginx-static/nginx-static_1.27.4_linux_x64_cflinuxfs3_d5dddd48.tgz
   sha256: d5dddd4877f70762dd784ecb8b84c3a71da25eb62f6b9bed8d34ebfc92c9e34d


### PR DESCRIPTION
See https://github.com/cloudfoundry/staticfile-buildpack/issues/179, this buildpack is supposed to have only 1 NGINX version line.

